### PR TITLE
Regular expressions with /g are stateful and Node 0.10 has a bug in string replace with /g RegExp.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,9 @@ function transformDecl (decl, opts) {
             url.value = convert(url.value, opts);
         }
 
+        escapeChars.lastIndex = 0;  // Required for Node JS v0.10
         if (escapeChars.test(url.value)) {
+            escapeChars.lastIndex = 0;
             escaped = url.value.replace(escapeChars, '\\$1');
             if (escaped.length < url.value.length + (url.type === 'string' ? 2 : 0)) {
                 url.value = escaped;


### PR DESCRIPTION
Node 0.12 onwards string replace works fine.

https://groups.google.com/forum/#!topic/v8-dev/VVuLI2VwHGU
http://stackoverflow.com/questions/1520800/why-regexp-with-global-flag-in-javascript-give-wrong-results